### PR TITLE
ensure re-export on loading grammar checker source

### DIFF
--- a/src/beyond_grammar_quill.ts
+++ b/src/beyond_grammar_quill.ts
@@ -319,6 +319,7 @@ export function initBeyondGrammar (fn: () => void) {
 
   ensureLoadGrammarChecker()
   .then(() => {
+    makeExports(); // To be sure we have not re-written namespace after loading the grammar checker sources
     return fn()
   })
   .catch((e: Error) => {


### PR DESCRIPTION
in case of isolated loading of quill plugin, it loads grammar checker which re-write the BeyondGrammar namespace